### PR TITLE
Add breadcrumbs (resolves #8)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,6 +8,28 @@ website:
   title: "Xetthecum Digital Ecocultural Mapping"
   search: false
   google-analytics: 'G-MM4PBW09LS'
+  sidebar:
+    contents:
+      - section: Home
+        href: index.qmd
+        contents:
+          - text: About the Project
+            href: about.qmd
+          - text: Meet the Team
+            href: team.qmd
+          - text: Research
+            href: research.qmd
+          - section: Browse all Species
+            href: taxa.qmd
+            contents: "taxa/*/index.qmd"
+          - text: Web of Life
+            href: web-of-life.qmd
+          - text: Cultural Values
+            href: cultural-values.qmd
+          - text: Ecological Communities
+            href: ecological-values.qmd
+          - text: Resources
+            href: resources.qmd
   navbar:
     right:
       - href: https://imerss.github.io/xetthecum-storymap-story/Xetthecum-Storymap-Reknitted.html

--- a/about.qmd
+++ b/about.qmd
@@ -1,5 +1,6 @@
 ---
 engine: knitr
+sidebar: false
 ---
 
 ::: {.column-screen}

--- a/about.qmd
+++ b/about.qmd
@@ -1,14 +1,13 @@
 ---
+title: About the Project
 engine: knitr
 sidebar: false
+banner: files/banner_about.png
+format:
+  html:
+    template-partials:
+      - partials/title-block.html
 ---
-
-::: {.column-screen}
-::: {.hero-banner style="background-image: url('files/banner_about.png');"}
-:::
-:::
-
-# About the Project
 
 The Xetthecum story map is based on an open source ecocultural mapping framework designed to serve the initiatives of the Indigenous-led organization [Whiteswan Environmental](https://www.whiteswanenvironmental.org/digital-ecocultural-mapping.html) (WE). The aim of this collaborative work is to restore traditional Indigenous practices and access to place, supporting thriving cultures and coastal ecosystems for future generations in the Salish Sea. WE initiated the Spirit of the Sxwo’le (SOS) Coalition, which guides its collaboration with the Institute for Multidisciplinary Ecological Research in the Salish Sea (IMERSS) and other non-Indigenous organizations, ensuring that work proceeds with respect for Indigenous leadership and protocols of cultural sensitivity and cultural humility. To learn more about the project and collaboration with Whiteswan Environmental please watch the YouTube video [Ecocultural Mapping in the Salish Sea](https://www.youtube.com/watch?v=0v84S7DeORU).
 

--- a/contact.qmd
+++ b/contact.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Contact"
 editor: visual
+sidebar: false
 ---
 
 ```{r}

--- a/css/styles.css
+++ b/css/styles.css
@@ -47,6 +47,10 @@ h2, .h2 {
   text-align: center;
 }
 
+.hero-banner-empty {
+  margin-block-end: 2em;
+}
+
 .hero-text {
   font-size: clamp(1rem, 5vw, 4rem);
   background: rgba(245,251,219, 0.8);

--- a/cultural-values.qmd
+++ b/cultural-values.qmd
@@ -1,5 +1,6 @@
 ---
 title: Cultural Values
+sidebar: false
 ---
 
 :::{.blurb-container}

--- a/data.qmd
+++ b/data.qmd
@@ -1,9 +1,10 @@
 ---
 title: "Data Download"
+sidebar: false
 ---
 
 
-Data collected as part of the ecocultural mapping project is available here. We have curated a heterogenious mix of different data types, which is bundled as versioned releases using Zenodo. 
+Data collected as part of the ecocultural mapping project is available here. We have curated a heterogenious mix of different data types, which is bundled as versioned releases using Zenodo.
 
 Details on how this data was prepared can be found in the [IMERSS bioinformatics github repository](https://github.com/IMERSS/imerss-bioinfo)
 
@@ -15,7 +16,7 @@ Details on how this data was prepared can be found in the [IMERSS bioinformatics
 
 A placeholder for when the data release is ready.
 
-This release contains two notable subsets: 
+This release contains two notable subsets:
 
 1. [Ecological data subset <i class="fa-solid fa-arrow-up-right-from-square"></i>]()
 2. [Cultural data subset <i class="fa-solid fa-arrow-up-right-from-square"></i>]()

--- a/ecological-values.qmd
+++ b/ecological-values.qmd
@@ -2,10 +2,11 @@
 title: Ecological Communities
 lightbox: true
 toc: true
+sidebar: false
 ---
 
 ## Thuthiqut - Forest
- 
+
 ### Including Mature, Young, and Pole Sapling
 
 :::{.blurb-container}

--- a/generate_pages.R
+++ b/generate_pages.R
@@ -98,6 +98,7 @@ make_page <- function(row, obs){
     '---\ntitle: ',
     row["hulquminumName"],
     '\nengine: knitr',
+    '\nsidebar: false',
     '\nimage: ',
     row["iNaturalistTaxonImage"],
     '\nimage-alt: ',

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 engine: knitr
+sidebar: false
 ---
 
 ::: {.column-screen}

--- a/partials/title-block.html
+++ b/partials/title-block.html
@@ -1,0 +1,30 @@
+$if(banner)$
+<div class="column-screen">
+    <div class="hero-banner hero-banner-empty" style="background-image: url('$banner$');">
+
+    </div>
+</div>
+$endif$
+<header id="title-block-header" class="quarto-title-block default">
+    $if(title)$
+        <div class="quarto-title">
+            <h1 class="title">$title$</h1>
+        </div>
+    $endif$
+    $if(subtitle)$
+    <p class="subtitle">$subtitle$</p>
+    $endif$
+    $for(author)$
+    <p class="author">$author$</p>
+    $endfor$
+
+    $if(date)$
+    <p class="date">$date$</p>
+    $endif$
+    $if(abstract)$
+    <div class="abstract">
+        <div class="abstract-title">$abstract-title$</div>
+        $abstract$
+    </div>
+    $endif$
+</header>

--- a/research.qmd
+++ b/research.qmd
@@ -1,6 +1,7 @@
 ---
 engine: knitr
 title: Research
+sidebar: false
 ---
 
 ## Works Cited

--- a/resources.qmd
+++ b/resources.qmd
@@ -1,5 +1,6 @@
 ---
 engine: knitr
+sidebar: false
 ---
 
 ::: {.column-screen}

--- a/resources.qmd
+++ b/resources.qmd
@@ -1,14 +1,13 @@
 ---
 engine: knitr
 sidebar: false
+title: Resources
+banner: files/banner_resources.png
+format:
+  html:
+    template-partials:
+      - partials/title-block.html
 ---
-
-::: {.column-screen}
-::: {.hero-banner style="background-image: url('files/banner_resources.png');"}
-:::
-:::
-
-# Resources
 
 ## Xetthecum Resources
 

--- a/taxa.qmd
+++ b/taxa.qmd
@@ -7,10 +7,9 @@ listing:
   #filter-ui: [categories]
   fields: [title, image, categories]
   image-height: 200px
+title: Browse all Species
 sidebar: false
 ---
-
-# Browse all species
 
 :::{#main-listing}
 :::

--- a/taxa.qmd
+++ b/taxa.qmd
@@ -7,6 +7,7 @@ listing:
   #filter-ui: [categories]
   fields: [title, image, categories]
   image-height: 200px
+sidebar: false
 ---
 
 # Browse all species

--- a/team.qmd
+++ b/team.qmd
@@ -1,6 +1,7 @@
 ---
 engine: knitr
 title: Meet the Team
+sidebar: false
 ---
 
 :::{.blurb-container}

--- a/web-of-life.qmd
+++ b/web-of-life.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Web of Life"
 engine: knitr
+sidebar: false
 ---
 
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />


### PR DESCRIPTION
Resolves #8 

- Configures the breadcrumbs by adding the side navigation configurations
- Adds configuration to hide the side navigation on each page
- Adds a title-block partial to override existing partial for pages that have a large banner image. So that the banner will appear above the header and breadcrumbs