### PR TITLE
Add a footer to the site (resolves #13)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -56,6 +56,10 @@ website:
           #  href: data.qmd
       - href: resources.qmd
         text: Resources
+  page-footer:
+    background: "#5A5244"
+    center: |
+      ![](/files/icon_array.png){fig-alt="" .footer-image}
 format:
   html:
     theme: [flatly, css/theme-light.scss]

--- a/about.qmd
+++ b/about.qmd
@@ -50,10 +50,3 @@ The Xetthecum story map includes cultural information about places, species, and
 [Northeast Pacific Coastal Biodiversity Action   Network](https://oceandecadenortheastpacific.org/projects/northeast-pacific-coastal-biodiversity-action-network)
 
 [UBC BRITE Internship Program](https://biodiversity.ubc.ca/training-and-award-opportunities  /brite/brite-internships)
-
-
-::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-:::

--- a/css/styles.css
+++ b/css/styles.css
@@ -198,6 +198,15 @@ p {
   margin-inline: 0;
 }
 
+.footer-image {
+  /*
+    To start, brightness(0) saturate(100%) need to be at the beginning to convert the image to black.
+    The remainder of the declaration is to convert the image to the target colour `#F2FCD6` from `--bs-body-bg`.
+    See: https://codepen.io/sosuke/pen/Pjoqqp
+  */
+  filter: brightness(0) saturate(100%) invert(88%) sepia(5%) saturate(840%) hue-rotate(35deg) brightness(106%) contrast(105%);
+}
+
 @media(max-width: 600px){
   .blurb-container{
    flex-direction: column;

--- a/cultural-values.qmd
+++ b/cultural-values.qmd
@@ -112,7 +112,3 @@ Example: [yuxwule’](/taxa/haliaeetus_leucocephalus) – bald eagle
 :::
 
 :::
-
-:::{.column-page}
-![](files/icon_array.png){text-align=center}
-:::

--- a/data.qmd
+++ b/data.qmd
@@ -20,8 +20,3 @@ This release contains two notable subsets:
 
 1. [Ecological data subset <i class="fa-solid fa-arrow-up-right-from-square"></i>]()
 2. [Cultural data subset <i class="fa-solid fa-arrow-up-right-from-square"></i>]()
-
-:::: {.column-page style="text-align:center"}
-![](files/icon_array.png)
-::::
-

--- a/ecological-values.qmd
+++ b/ecological-values.qmd
@@ -130,12 +130,3 @@ Puneluxutth’ elder Thiyuas (Florence James) calls this type of ecosystem shthu
 In addition to p’hwulhp (Garry oaks) which provide medicinal bark, camas meadows may also include scattered qaanlhp (arbutus), which provide medicinal bark and leaves as well as edible berries. While they prefer wetter areas, occasionally other trees can survive in camas meadows, such as ts’alhulhp (bigleaf maple), which provides leaves to flavour camas pit cook feasts, edible flowers and medicinal shoots, sap and cambium. Ts’sey (Douglas-fir) is also common in woodlands, and is valued for many uses, such as tools, poles and pitch.
 
 Camas meadows on Galiano are critically important to maintaining the island’s biodiversity. “Together, Garry oak and associated ecosystems are home to more plant species than any other terrestrial ecosystem in coastal British Columbia. Many of these species occur nowhere else in Canada. Collectively, Garry oak ecosystems are among the most endangered in Canada – less than 5% of the original habitat remains in a near-natural condition.” (GOERT, 2003) On Galiano, Garry oak and associated ecosystems are generally limited to steep, south-southwest facing slopes and shoreline areas. They tend to occur in areas with very dry shallow soils or that are too exposed to wind and sun for forest ecosystems to flourish.
-
-<br>
-
-:::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-::::
-

--- a/research.qmd
+++ b/research.qmd
@@ -50,11 +50,3 @@ Thiyuas (Florence James), interviewed by Jeannine Georgeson, Levi Wislon & Andre
 
 
 Please note that this is a living, ongoing project, and that this resource list will always be incomplete. Your contributions and ideas are welcome. If you’d like to make suggestions about the resource list or anything else on this website, please contact Jeanine Georgeson (jeannine@imerss.org)
-
-:::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-::::
-
-

--- a/resources.qmd
+++ b/resources.qmd
@@ -66,11 +66,3 @@ Other groups have put together excellent resource lists and we are grateful for 
 
 * [Hul’q’umi’num’ Animal Bingo](https://scratch.mit.edu/projects/895188484/fullscreen/) (from NLPS Indigenous Education Resources)
 * [Hul’q’umi’num’ Feelings Bingo](https://scratch.mit.edu/projects/816040858/) (from NLPS Indigenous Education Resources
-
-:::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-::::
-
-

--- a/taxa.qmd
+++ b/taxa.qmd
@@ -13,12 +13,3 @@ sidebar: false
 
 :::{#main-listing}
 :::
-
-<br>
-
-:::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-::::
-

--- a/team.qmd
+++ b/team.qmd
@@ -226,9 +226,3 @@ Project Coordinator
 Media Contributor
 :::
 :::
-
-::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-:::

--- a/web-of-life.qmd
+++ b/web-of-life.qmd
@@ -47,11 +47,3 @@ hortis.sunburstLoader(".fl-imerss-container", {
   commonNames: false
 });
 </script>
-
-<br>
-
-:::: {.column-page}
-<center>
-![](files/icon_array.png)
-</center>
-::::


### PR DESCRIPTION
Resolves #13 

- Adds a page footer with the icon array image
- Removes the icon array image added individually to the bottom of the pages

## Comments

@dayotte I ended up using the page footer despite the fact that I can only take up the centre column. This is because using a body-footer or just placing it on the page will not fully extend the background colour to the bottom of the page.

Another note is that I used the existing icon_array.png file and used CSS to manipulate the colour. In this way we can reuse the same image that is used on the Homepage.