### PR TITLE
Reduce vertical space between images on Ecological Communities page (resolves #14)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -198,6 +198,15 @@ p {
   margin-inline: 0;
 }
 
+.align-start {
+  align-items: flex-start;
+}
+
+.align-start h3 {
+  margin-block-start: 0;
+  padding-block-start: 0;
+}
+
 @media(max-width: 600px){
   .blurb-container{
    flex-direction: column;

--- a/ecological-values.qmd
+++ b/ecological-values.qmd
@@ -7,115 +7,78 @@ sidebar: false
 
 ## Thuthiqut - Forest
 
+:::{.blurb-container .align-start}
+:::{.blurb-half-column}
+
 ### Including Mature, Young, and Pole Sapling
 
-:::{.blurb-container}
-:::{.blurb-half-column}
 Shaped by interactions between water, soil, terrain, climate and the multitudes of beings that live within them, forests are a sanctuary for hundreds of thousands of species of plants, fungi, mammals, birds, insects and microorganisms. Forests provide shelter, clean water, and food, the foundations for a complex web of life in which we are intricately interconnected. Humans have been stewarding forests on Galiano since time out of mind, in order to ensure key species that we depend on can flourish and help us thrive.
 
 Dry ridges or steep southwest facing slopes with nutrient poor, shallow soils tend to be dominated by a mix of gnarled ts’sey (Douglas-fir) and qaanlhp (arbutus), and shrubby species such as lulutth’sulhp (dull oregon grape) or xwiinlhp (baldhip rose), all of which valued as medicine. These drier forested communities are mapped as woodlands in this map.
 
-:::
-:::{.blurb-half-column}
-![mature forest](files/Rectangle 790.png)
-:::
-:::
-
-
-
-:::{.blurb-container}
-:::{.blurb-half-column}
-
 Moister forests are characterized by towering ts’sey (Douglas-fir) and robust xpey’ (western red cedar). Xpey’ is known as the ‘tree of life’, as it provides essential material for everything from ocean-worthy canoes, to rot-resistant buildings, beautiful carvings, and woven rain hats. Oldgrowth xpey’ are most valued for these purposes, and are allowed to grow slowly for hundreds of years to provide fine and clear-grained bark for weaving and wood for carving. Traditional Indigenous harvesting methods of only taking a strip of bark or plank of wood from one side allows such trees to survive, heal and continue growing. The understory in this type of forest is inhabited by plants resistant to the fungicide xpey’ releases into the soil to discourage competition from other plants. This type of forest is often thick with t’eqe’ (salal) and suniiulhp (dull Oregon grape), both of which provide nutritious berries. Sthxélem (sword fern) is also common in such forests, and is regarded as a spiritually significant plant.
 
-:::
-:::{.blurb-half-column}
-![young forest](files/Rectangle 791.png)
-:::
-:::
-
-:::{.blurb-container}
-:::{.blurb-half-column}
 These older forests are models of complexity, exhibiting a vast diversity of composition (the parts), structure (the arrangement of the parts), and function (how the parts interact with one another). Moss-covered ts’alhulhp (bigleaf maple) offer habitat for other culturally significant species, such as tl’usiip (licorice fern), which Thiyuas and her family used as a sweetener: If one gently lifts the moss with your pinky to reveal the root, the licorice fern root can be rinsed, chopped up, mixed with berries, and placed on a board in the sun to dry.
 
 In mature and old growth forests, trees are present in all stages of their life cycles including standing dead snags and fallen debris, providing critical habitat for culturally significant species such as yuxwule’ (bald eagle) and ha’put (black tailed deer). Forests are valued for hunting ha’put from September to October, although Thiyuas cautions that one should not hunt females or hunt after the rut, but wait until after the ironwood (qethulhp) blooms turned brown. As a ritual, the first deer hunted was always shared; each species had their rules and rituals. It is tradition to bring an elder a piece of meat from hunting, just as one shares the first fish caught during seafood harvests.
 
 :::
 :::{.blurb-half-column}
+![mature forest](files/Rectangle 790.png)
+
+![young forest](files/Rectangle 791.png)
+
 ![pole sapling](files/Rectangle 792.png)
 :::
 :::
 
+
 ## Tl'elhumqa' - Freshwater
+
+:::{.blurb-container .align-start}
+:::{.blurb-half-column}
 
 ### Including Riparian and Wetland
 
-:::{.blurb-container}
-:::{.blurb-half-column}
 Healthy wetlands, lakes and streams are havens for humans and wildlife alike, providing critical habitat and a source of freshwater. A diversity of plant life, bacteria and insects thrive in these ecosystems, forming complex food webs that support many culturally important species, such as stseelhtun (salmon). The enhanced growth and forest structure found in riparian areas provides necessary cover for wildlife, which is also important for culturally significant activities such as hunting and birdwatching. Animals such as ha’put (black tailed deer) and smuqw’a’ (great blue heron) depend on freshwater areas for food and water.
 
-:::
-:::{.blurb-half-column}
-![riparian](files/Rectangle 797.png)
-:::
-:::
-
-:::{.blurb-container}
-:::{.blurb-half-column}
 Wetlands on Galiano include lakes, shallow water, swamps, marshes, wet meadows, fens, and bog communities, many of which are represented in the watershed that flows into Xetthecum. Swamps and riparian areas include flood-tolerant trees such as xpey’ (western red cedar) which “like to have their feet wet”, kwulala’ulhp (red alder), whose inner bark offers a source of emergency food in the spring, and swele’ulhp (willow), which is useful for making fish traps. Other helpful plants that grow here include stth’e’qun (cattail) which provides a useful source of materials for both binding and insulation, sxum’xum’ (horsetail), which makes a yellow brown dye and ts’a’kw’a’ (skunk cabbage) which can be used to wrap food to keep it fresh. These areas are prized for berry-picking and gathering other edible and medicinal plants such as lila’ (salmonberry), t’uqwum’ (thimbleberry), t’eqe’ (salal), suniiulhp (Oregon grape), sqw’uqwtsus (red huckleberry) and me’uwhulhp (Labrador tea).
 
-:::
-:::{.blurb-half-column}
-![wetland](files/Rectangle 798.png)
-:::
-:::
-
-:::{.blurb-container}
-:::{.blurb-half-column}
 Colonial settlers began to alter Galiano’s landscape in the late 1800’s in ways that were very different from the strategies used by pre-contact First Nations communities. Instead of respecting the integrity of streams, wetlands and riparian areas and honouring the role that sqwul’ew’ (beaver) play in revitalizing freshwater ecosystems, these areas have been focal points for resource extraction, agriculture, logging, construction, transportation and waste disposal. Greig Creek is one of many watersheds on Galiano Island that have been heavily impacted by these activities.
 
 :::
 :::{.blurb-half-column}
+![riparian](files/Rectangle 797.png)
+
+![wetland](files/Rectangle 798.png)
+
 ![creek](files/Rectangle 799.png)
 :::
 :::
 
 ## Hwuiumqa' - Marine
 
+:::{.blurb-container .align-start}
+:::{.blurb-half-column}
+
 ### Including Shoreline and Subtidal
 
-:::{.blurb-container}
-:::{.blurb-half-column}
 Surrounded by water, Galiano Islanders see the ocean as intrinsic to living and loving life on this island. Sightings of q’ul-lhanamutsum (orcas) and other marine mammals are treasured hallmarks of island life. However, for many community members, the ocean is first and foremost a source of food and livelihood. Both Indigenous and non-Indigenous people on Galiano enjoy fish such as thuqi’ (sockeye salmon), haan (pink salmon), tuqwtuqw (red snapper) and other t’q’as (rockfish). Also prized are s-axwa’ (butter clam), kwuneem’mun’ (scallops), ey’x (dungeness crab), thikwt (sea cucumber) and seaweeds such as lhuq’us (red laver). Thiyuas (Florence James) shared that ’e s-hw (harbour seal) is also prized as a dark meat.
 
-
-:::
-:::{.blurb-half-column}
-![shoreline](files/Rectangle 794.png)
-:::
-:::
-
-:::{.blurb-container}
-:::{.blurb-half-column}
 Xetthecum (Retreat Cove) is one of the few marine locations on the shoreline of Galiano itself that has been an important place for fishing and harvesting shellfish. Its importance as a habitat for t’q’as (rockfish) in particular has since become so notable that it has been designated a marine protected area, where fishing is banned to protect these long-lived species that are so slow to reproduce. As the tide is not too fast, Xetthecum was once also a good area for harvesting other creatures, such as pun’eq’ (geoduck) and dog fish. It is important that community members are able to harvest and consume these foods without getting sick, therefore the environmental health of the ocean is vital.
 
 Culturally significant beaches and shorelines on Galiano Island, such as those near Xetthecum are used as places to congregate for picnics, social events, ceremonial sites, and as food gathering sites by local First Nations peoples. Bays, inlets, and coves like Xetthecum are also a place of safe harbour during storms, or places to moor one’s boat during winters.
 
-:::
-:::{.blurb-half-column}
-![subtidal](files/Rectangle 795.png)
-:::
-:::
-
-:::{.blurb-container}
-:::{.blurb-half-column}
 Many, if not all, of the Indigenous families associated with Galiano have been fishing since time out of mind. The Seafood Fest has been an extremely significant annual cultural event for decades primarily because so many of the island’s inhabitants have been passing down the skills, knowledge and secret locations of where to find the best sources of seafood for generations. Unfortunately, due to over-fishing, destruction of marine habitat, pollution and other industrial causes, the bounty of the sea has become so limited that few members of the next generation can make a living fishing, and most of the menu for the Seafood Fest now has to be purchased from elsewhere.
 
 In the past, no one would ever reveal the locations of where to harvest seafood, but now such knowledge is often recounted as memories of now lost or declining biodiversity. Locations of significance include Porlier Pass and Walker Hook off of Saltspring for t’q’as (rockfish) and Pinnacle Rock on the south side of Porlier Pass for ’eeyt (lingcod). As for salmon, Cable Bay was once a good location for kw’a’luhw (chum salmon), as was Enterprise Reef off of Mayne Island and areas around Valdes Island. Yet many fishing areas that have been important for Indigenous community members on Galiano over the past hundred years are much farther away, necessitating long periods of time that families are separated. The closest of these locations include the west coast of Vancouver Island such as Jordan River, Race Rocks, San Juan Harbour near Port Renfrew, and areas near River’s Inlet to the Skeena.
 
-
 :::
 :::{.blurb-half-column}
+![shoreline](files/Rectangle 794.png)
+
+![subtidal](files/Rectangle 795.png)
+
 ![eelgrass beds](files/Rectangle 796.png)
 :::
 :::


### PR DESCRIPTION
Resolves #14 

- Reconfigures page content to put text and images in separate columns
- Updates styling to align content to the top of the column